### PR TITLE
fix mobile style

### DIFF
--- a/skins/ArchLinux/mobile.css
+++ b/skins/ArchLinux/mobile.css
@@ -125,3 +125,7 @@ div.searchresult {
 input#searchInput {
 	width: 13em;
 }
+
+a.extiw {
+    word-break: break-word;
+}


### PR DESCRIPTION
https://wiki.archlinuxjp.org/index.php/%E3%83%97%E3%83%AD%E3%82%AA%E3%83%BC%E3%83%87%E3%82%A3%E3%82%AA

上の記事の`関連記事`にあるリンクがはみ出て見えますので、その修正です。
